### PR TITLE
refactor: New architecture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "dota-gsi"
 version = "0.2.2"
 dependencies = [
@@ -249,6 +255,7 @@ dependencies = [
  "env_logger",
  "httparse",
  "log",
+ "pretty_assertions",
  "serde",
  "serde_json",
  "thiserror",
@@ -466,6 +473,16 @@ name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -975,3 +992,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,8 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 thiserror = "^2.0"
 tokio = { version = "1", features = ["net", "rt", "macros", "rt-multi-thread", "io-util", "fs", "sync"] }
+
+
+[dev-dependencies]
+pretty_assertions = "1"
+tokio = { version = "1", features = ["net", "rt", "macros", "rt-multi-thread", "io-util", "fs", "sync", "time"] }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![crates.io](https://img.shields.io/crates/v/dota-gsi.svg)](https://crates.io/crates/dota-gsi)
 [![CI/CD](https://github.com/tomasfarias/dota-gsi/actions/workflows/cd.yaml/badge.svg)](https://github.com/tomasfarias/dota-gsi/actions)
 
-Game State Integration with Dota 2 in rust. Provides a server that listens for JSON events sent by Dota 2.
+Game State Integration with Dota 2 in Rust. Provides a server that listens for requests sent by Dota 2, processes them to extract their JSON payloads, and broadcasts the payloads to any user-configured handlers.
 
 # Requirements
 
@@ -45,49 +45,61 @@ Here's a sample configuration file:
 }
 ```
 
-Take note of the URI used in the configuration file as it must be the same URI used when creating a new `GSIServer`.
+Note the URI used in the configuration file must be the same URI used when initializing a `Server`.
 
 # Examples
 
-Examples showcase how to implement handlers that parse the game state data and do whatever we want with it.
+## Echoslam: echo game state integration
 
-## Echoslam: echo back data received by the server
+This program echoes game state integration events either in raw JSON or after deserialization into components provided by this library. The full program is available at [`src/bin/echoslam.rs`](./src/bin/echoslam.rs)
 
-This program uses the provided component models to attempt to parse the JSON received by the server. See the full program at [`src/bin/echoslam.rs`](./src/bin/echoslam.rs)
-
-We simply define two echo handlers as:
+The program defines a handler to handle game state integration events by deserializing them to `T` (which is later defined to be `serde_json::Value` or `components::GameState`:
 
 ```rust
-use dota::{components::GameState, GSIServer};
+use dota::{Server, components::GameState};
 
-/// Echo back Dota GameState integration state.
-async fn echo_gamestate_handler(gs: GameState) {
-    println!("{}", gs);
-}
+/// Echo back game state integration events.
+async fn echo_handler<T>(bytes: bytes::Bytes)
+where
+    T: DeserializeOwned + std::fmt::Display,
+{
+    let value: T = match serde_json::from_slice(&bytes) {
+        Err(e) => {
+            log::error!("Failed to deserialize JSON body: {}", e);
+            panic!("deserialize error");
+        }
+        Ok(v) => v,
+    };
 
-/// Echo back raw JSON events.
-async fn echo_json_handler(value: serde_json::Value) {
-    println!("{}", value);
-}
-```
-
-Initialize the `GSIServer` using command line arguments with:
-
-```rust
-let server = GSIServer::new(&args.uri);
-```
-
-And we pass the handlers to the server when running:
-
-```rust
-if args.raw {
-    server.run(echo_json_handler).await?;
-} else {
-    server.run(echo_gamestate_handler).await?;
+    println!("{:#}", value);
 }
 ```
 
-We have defined a command line flag that determines whether we are attempting to parse the JSON data before echoing it or passing the raw JSON.
+A handler must implement the `Handler` trait, which is automatically implemented for async functions like this one, so it can be directly used in the next step.
+
+In the `main` function, we run the `Server`. This includes first configuring the URI the `Server` will be listening on, and passing the handler function with `T` depending on inputs:
+
+```rust
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    let args = Args::parse();
+
+    let mut server = Server::new(&args.uri);
+
+    if args.raw {
+        server = server.register(echo_handler::<serde_json::Value>);
+    } else {
+        server = server.register(echo_handler::<GameState>);
+    }
+
+    server.run().await?;
+    Ok(())
+}
+```
+
+Finally, the server runs forever.
 
 This program is provided with `dota-gsi` and can be compiled with:
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-edition = "2021"
+edition = "2024"

--- a/src/bin/echoslam.rs
+++ b/src/bin/echoslam.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use serde::de::DeserializeOwned;
 
-use dota::{components::GameState, Server};
+use dota::{Server, components::GameState};
 
 /// Echo back game state integration events.
 async fn echo_handler<T>(bytes: bytes::Bytes)

--- a/src/bin/echoslam.rs
+++ b/src/bin/echoslam.rs
@@ -4,11 +4,11 @@ use serde::de::DeserializeOwned;
 use dota::{Server, components::GameState};
 
 /// Echo back game state integration events.
-async fn echo_handler<T>(bytes: bytes::Bytes)
+async fn echo_handler<T>(event: bytes::Bytes)
 where
     T: DeserializeOwned + std::fmt::Display,
 {
-    let value: T = match serde_json::from_slice(&bytes) {
+    let value: T = match serde_json::from_slice(&event) {
         Err(e) => {
             log::error!("Failed to deserialize JSON body: {}", e);
             panic!("deserialize error");
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         server = server.register(echo_handler::<GameState>);
     }
 
-    server.serve().await?;
+    server.run().await?;
 
     Ok(())
 }

--- a/src/bin/echoslam.rs
+++ b/src/bin/echoslam.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         server = server.register(echo_handler::<GameState>);
     }
 
-    server.run().await?;
+    server.serve().await?;
 
     Ok(())
 }

--- a/src/bin/recall.rs
+++ b/src/bin/recall.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         output_dir: output_dir.clone(),
     };
 
-    Server::new(&args.uri).register(handler).serve().await?;
+    Server::new(&args.uri).register(handler).run().await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Changes

### New handler trait

New `Handler` trait, replaces `GameStateHandler`. It is implemented for all async fn, and can be implemented by users. 

### New architecture

`GSIServer` is now just `Server`, and it allows registering multiple handlers. Each handler runs as a background task managed by a new `HandlerRegistration` struct. Each handler is passed an events as bytes. Deserialization is left up to handler developers. 

The actual socket listening and processing is also moved to background task wrapped in a new `Listener` struct. This allows supporting shutting down the server cleanly.

Updated `echoslam` and `recall` to work with new abstractions.

### TODO

- [x] Update README
- [ ] Formalize models for events, potentially let handlers consume events already deserialized. Leaving this for a follow-up PR.

## Testing

Added new unit test. 